### PR TITLE
exclude clashing guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,12 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>2.4.0</version>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.4.0</version>
+            <version>2.5.0</version>
         </dependency>
         <!-- google -->
         <dependency>
@@ -75,8 +75,15 @@
             <artifactId>google-api-client</artifactId>
             <version>1.19.0</version>
             <type>jar</type>
-         </dependency>
-         <dependency>
+            <exclusions>
+                <exclusion>
+                    <!-- guava-18.0 is included as a dependency by io.springfox:springfox-swagger2; exclude this older/clashing version -->
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava-jdk5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson</artifactId>
             <version>1.19.0</version>


### PR DESCRIPTION
google-api-client pulls in an older guava version which clashes with the version pulled in from springfox-swagger2.
The older dependency is now excluded.