### PR TITLE
Fix bug in single attribute api endpoint

### DIFF
--- a/src/main/java/org/cbioportal/cdd/model/ClinicalAttributeMetadata.java
+++ b/src/main/java/org/cbioportal/cdd/model/ClinicalAttributeMetadata.java
@@ -22,13 +22,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import io.swagger.annotations.ApiModelProperty;
-
 import java.util.*;
 
 /**
- * @author Avery Wang, Manda Wilson 
+ * @author Avery Wang, Manda Wilson
  */
 @JsonInclude(Include.NON_NULL)
 @JsonPropertyOrder({
@@ -69,8 +67,7 @@ public class ClinicalAttributeMetadata {
     */
     private ClinicalAttributeMetadata() {}
 
-
-    /**
+    /** Primitive Arguments Constructor
     *
     * @param columnHeader
     * @param priority
@@ -86,6 +83,27 @@ public class ClinicalAttributeMetadata {
         this.datatype = datatype;
         this.attributeType = attributeType;
         this.priority = priority;
+    }
+
+    /** Copy Constructor
+    *
+    * @param clinicalAttributeMetadata
+    */
+    public ClinicalAttributeMetadata(ClinicalAttributeMetadata otherObject) {
+        this.studyId = otherObject.getStudyId();
+        this.columnHeader = otherObject.getColumnHeader();
+        this.displayName = otherObject.getDisplayName();
+        this.description = otherObject.getDescription();
+        this.datatype = otherObject.getDatatype();
+        this.attributeType = otherObject.getAttributeType();
+        this.priority = otherObject.getPriority();
+        Map<String, Object> otherObjectAdditionalProperties = otherObject.getAdditionalProperties();
+        if (otherObjectAdditionalProperties != null) {
+            for (String key : otherObjectAdditionalProperties.keySet()) {
+                Object value = otherObjectAdditionalProperties.get(key);
+                this.setAdditionalProperty(key, value);
+            }
+        }
     }
 
     /**

--- a/src/test/java/org/cbioportal/cdd/ClinicalDataDictionaryTest.java
+++ b/src/test/java/org/cbioportal/cdd/ClinicalDataDictionaryTest.java
@@ -96,6 +96,22 @@ public class ClinicalDataDictionaryTest {
     }
 
     @Test
+    public void getClinicalAttributeMetadataFilteredWithOverrideForMskimpactTest() throws Exception {
+        // test that an attribute not overridden by cancerStudy mskimpact has default priority 1
+        List<String> columnHeaders = Arrays.asList("DISEASE_STAGE");
+        ResponseEntity<String> response = restTemplate.postForEntity("/api/", columnHeaders, String.class);
+        assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode responseJSON = mapper.readTree(response.getBody());
+        assertThat(response.getBody(), containsString("\"priority\":\"1\""));
+        // query again with cancerStudy mskimpact and look for default priority 0
+        response = restTemplate.postForEntity("/api/?cancerStudy=mskimpact", columnHeaders, String.class);
+        assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
+        responseJSON = mapper.readTree(response.getBody());
+        assertThat(response.getBody(), containsString("\"priority\":\"0\""));
+    }
+
+    @Test
     public void getClinicalAttributeMetadataInvalidClinicalAttributeTest() throws Exception {
         // test an invalid clinical attribute throws an exception in POST /api/
         List<String> columnHeaders = Arrays.asList("AGE", "LAST_status", "INVALID_ATTRIBUTE");
@@ -109,8 +125,20 @@ public class ClinicalDataDictionaryTest {
         // test we can get one clinical attribute returned by GET /api/AGE/
         ResponseEntity<String> response = restTemplate.getForEntity("/api/AGE/", String.class);
         assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
-
         assertThat(response.getBody(), equalTo("{\"column_header\":\"AGE\",\"display_name\":\"Diagnosis Age\",\"description\":\"Age at which a condition or disease was first diagnosed.\",\"datatype\":\"NUMBER\",\"attribute_type\":\"PATIENT\",\"priority\":\"1\"}"));
+    }
+
+    @Test
+    public void getClinicalAttributeWithOverrideForMskimpactTest() throws Exception {
+        // test that an attribute not overridden in mskimpact has default priority 1 normally
+        String testAttribute = "DISEASE_STAGE";
+        ResponseEntity<String> response = restTemplate.getForEntity("/api/" + testAttribute, String.class);
+        assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
+        assertThat(response.getBody(), containsString(",\"priority\":\"1\""));
+        // query again with cancerStudy mskimpact and look for default priority 0
+        response = restTemplate.getForEntity("/api/" + testAttribute + "?cancerStudy=mskimpact", String.class);
+        assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
+        assertThat(response.getBody(), containsString(",\"priority\":\"0\""));
     }
 
     @Test


### PR DESCRIPTION
- bug was that this endpoint was not applying the special logic for studies which alter the default clinical attribute metadata for certain studies (such as mskimpact)
- added unit tests to the single and list API endpoints (passing columnHeaders with study mskimpact)
- service for that endpoint now calls the service for the list of columnHeader endpoint
- simplified code by making a copy constructor for ClinicalAttributeMetadata
- simplified logic for choosing the correct default/override/alteredDefault metadata
- captured set of "special" studies in a named static final Set<String>
- added a function to clone/alter default attributes when queried with "special" studies
- dropped trailing whitespace