### PR TITLE
change to expecting ColumnHeader to be in prefLabel

### DIFF
--- a/src/main/java/org/cbioportal/cdd/repository/topbraid/ClinicalAttributeMetadataRepositoryTopBraidImpl.java
+++ b/src/main/java/org/cbioportal/cdd/repository/topbraid/ClinicalAttributeMetadataRepositoryTopBraidImpl.java
@@ -48,7 +48,7 @@ public class ClinicalAttributeMetadataRepositoryTopBraidImpl extends TopBraidRep
         "        ?node skos:broader ?parent. " +
         "        ?parent cdd:StudyId ?study_id. " +
         "        ?parent skos:broader ?grandparent. " +
-        "        ?grandparent rdfs:label ?column_header. " +
+        "        ?grandparent skos:prefLabel ?column_header. " +
         "        OPTIONAL{?node cdd:PriorityValue ?PriorityValue}. " +
         "        OPTIONAL{?node cdd:AttributeTypeValue ?AttributeTypeValue}. " +
         "        OPTIONAL{?node cdd:DatatypeValue ?DatatypeValue}. " +
@@ -66,7 +66,7 @@ public class ClinicalAttributeMetadataRepositoryTopBraidImpl extends TopBraidRep
         "SELECT ?column_header ?display_name ?attribute_type ?datatype ?description ?priority " +
         "WHERE { " +
         "    GRAPH <urn:x-evn-master:clinical_data_dictionary> { " +
-        "        ?subject rdfs:label ?column_header. " +
+        "        ?subject skos:prefLabel ?column_header. " +
         "        ?subject cdd:AttributeType ?attribute_type. " +
         "        ?subject cdd:Datatype ?datatype. " +
         "        ?subject cdd:Description ?description. " +


### PR DESCRIPTION
- the TopBraid gui forces new nodes to appear under skos:prefLabel rather than rdf:label
- to make things easier for creation in TopBraid UI, we are moving all current concepts to prefLabel representation