### PR TITLE
CDD Cache system set to never null-out

### DIFF
--- a/src/main/java/org/cbioportal/cdd/service/exception/FailedCacheRefreshException.java
+++ b/src/main/java/org/cbioportal/cdd/service/exception/FailedCacheRefreshException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+package org.cbioportal.cdd.service.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FailedCacheRefreshException extends RuntimeException {
+
+    private static final Logger logger = LoggerFactory.getLogger(FailedCacheRefreshException.class);
+
+    public FailedCacheRefreshException(String error) {
+        super(error);
+        logger.error(error);
+    }
+
+}
+

--- a/src/main/java/org/cbioportal/cdd/service/internal/ClinicalDataDictionaryServiceImpl.java
+++ b/src/main/java/org/cbioportal/cdd/service/internal/ClinicalDataDictionaryServiceImpl.java
@@ -28,6 +28,7 @@ import org.cbioportal.cdd.service.ClinicalDataDictionaryService;
 import org.cbioportal.cdd.service.exception.CancerStudyNotFoundException;
 import org.cbioportal.cdd.service.exception.ClinicalAttributeNotFoundException;
 import org.cbioportal.cdd.service.exception.ClinicalMetadataSourceUnresponsiveException;
+import org.cbioportal.cdd.service.exception.FailedCacheRefreshException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -144,9 +145,8 @@ public class ClinicalDataDictionaryServiceImpl implements ClinicalDataDictionary
     }
 
     @Override
-    public Map<String, String> forceResetCache() throws ClinicalMetadataSourceUnresponsiveException {
-        clinicalAttributesCache.resetCache(true);
-        assertCacheIsValid();
+    public Map<String, String> forceResetCache() throws FailedCacheRefreshException {
+        clinicalAttributesCache.resetCache();
         return Collections.singletonMap("response", "Success!");
     }
 

--- a/src/main/java/org/cbioportal/cdd/web/ClinicalDataDictionaryController.java
+++ b/src/main/java/org/cbioportal/cdd/web/ClinicalDataDictionaryController.java
@@ -37,6 +37,7 @@ import org.cbioportal.cdd.service.ClinicalDataDictionaryService;
 import org.cbioportal.cdd.service.exception.ClinicalAttributeNotFoundException;
 import org.cbioportal.cdd.service.exception.ClinicalMetadataSourceUnresponsiveException;
 import org.cbioportal.cdd.service.exception.CancerStudyNotFoundException;
+import org.cbioportal.cdd.service.exception.FailedCacheRefreshException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -131,6 +132,10 @@ public class ClinicalDataDictionaryController {
         response.sendError(HttpStatus.NOT_FOUND.value(), e.getMessage());
     }
 
+    @ResponseStatus(code = HttpStatus.SERVICE_UNAVAILABLE, reason = "Failed to refresh metadata cache")
+    @ExceptionHandler(FailedCacheRefreshException.class)
+    public void handleFailedCacheRefreshException() {}
+    
     @ResponseStatus(code = HttpStatus.SERVICE_UNAVAILABLE, reason = "Clinical attribute metadata source unavailable")
     @ExceptionHandler(ClinicalMetadataSourceUnresponsiveException.class)
     public void handleClinicalMetadataSourceUnresponsive() {}

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -1,3 +1,5 @@
 topbraid.url=
 topbraid.username=
 topbraid.password=
+
+slack.url=


### PR DESCRIPTION
- a cache reset will never null out the cache (regardless of whether or not cache is expired or invalid)
- refreshCache endpoint will throw a FailedCacheRefreshException instead of a ClinicalMetadataSourceUnavailableException
- a null cache (which shouldn't happen unless Topbraid is wiped) will throw ClinicalMetadataSourceUnavailableException

- date of last cache refresh is stored
- cache is now periodically checked every 10 minutes to see if cache is expired (based on date)
- stale cache will trigger resetCache()
- if resetCache does not complete successfully -- it will send a slack message alert

Unit test to check validateCacheAge  function