### PR TITLE
New Search Endpoint /api/search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>springfox-swagger-ui</artifactId>
             <version>2.5.0</version>
         </dependency>
+	<dependency>
+    	    <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8.1</version>
+	</dependency>
         <!-- google -->
         <dependency>
             <groupId>com.google.http-client</groupId>

--- a/src/main/java/org/cbioportal/cdd/model/ClinicalAttributeMetadata.java
+++ b/src/main/java/org/cbioportal/cdd/model/ClinicalAttributeMetadata.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.*;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Avery Wang, Manda Wilson
@@ -255,4 +257,37 @@ public class ClinicalAttributeMetadata {
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
+
+    public boolean containsSearchTerm(String searchTerm) {
+        return (StringUtils.containsIgnoreCase(this.columnHeader, searchTerm) ||
+            StringUtils.containsIgnoreCase(this.displayName, searchTerm) ||
+            StringUtils.containsIgnoreCase(this.description, searchTerm));   
+    }
+    
+    public boolean containsAllSearchTerms(List<String> searchTerms) {
+        for (String searchTerm : searchTerms) {
+            if (!containsSearchTerm(searchTerm)) {
+                return false;
+            }
+        }
+        return true;
+    }
+                
+    public Integer levenshteinDistanceFromSearchTerm(String searchTerm) {
+        Integer levenshteinDistance = Integer.MAX_VALUE;
+        if (StringUtils.containsIgnoreCase(this.columnHeader, searchTerm)) {
+            levenshteinDistance = Math.min(levenshteinDistance, StringUtils.getLevenshteinDistance(searchTerm, this.columnHeader));
+        } 
+        if (StringUtils.containsIgnoreCase(this.displayName, searchTerm)) {
+            levenshteinDistance = Math.min(levenshteinDistance, StringUtils.getLevenshteinDistance(searchTerm, this.displayName));
+        }
+        if (StringUtils.containsIgnoreCase(this.description, searchTerm)) {
+            levenshteinDistance = Math.min(levenshteinDistance, StringUtils.getLevenshteinDistance(searchTerm, this.description));
+        }
+        return levenshteinDistance;
+    } 
+
+    public boolean matchesAttributeType(String attributeType) {
+        return attributeType == null || attributeType.toUpperCase().equals(this.attributeType);
+    }   
 }

--- a/src/main/java/org/cbioportal/cdd/service/ClinicalDataDictionaryService.java
+++ b/src/main/java/org/cbioportal/cdd/service/ClinicalDataDictionaryService.java
@@ -29,6 +29,7 @@ public interface ClinicalDataDictionaryService {
     List<CancerStudy> getCancerStudies();
     List<ClinicalAttributeMetadata> getClinicalAttributeMetadata(String cancerStudy);
     List<ClinicalAttributeMetadata> getMetadataByColumnHeaders(String cancerStudy, List<String> columnHeaders) throws ClinicalAttributeNotFoundException;
+    List<ClinicalAttributeMetadata> getMetadataBySearchTerms(List<String> searchTerms, String attributeType, boolean inclusiveSearch) throws ClinicalAttributeNotFoundException;
     ClinicalAttributeMetadata getMetadataByColumnHeader(String cancerStudy, String columnHeader) throws ClinicalAttributeNotFoundException;
     Map<String, String> forceResetCache();
 }

--- a/src/main/java/org/cbioportal/cdd/service/internal/LevenshteinDistanceCache.java
+++ b/src/main/java/org/cbioportal/cdd/service/internal/LevenshteinDistanceCache.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+package org.cbioportal.cdd.service.internal;
+
+import javax.annotation.PostConstruct;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import java.time.ZonedDateTime;
+
+import org.apache.http.*;
+import org.apache.http.client.*;
+import org.apache.http.entity.*;
+import org.apache.http.impl.client.*;
+import org.apache.http.client.methods.*;
+
+import org.cbioportal.cdd.model.ClinicalAttributeMetadata;
+import org.cbioportal.cdd.repository.ClinicalAttributeMetadataRepository;
+import org.cbioportal.cdd.service.exception.FailedCacheRefreshException;
+
+import com.google.common.base.Strings;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Avery Wang
+ */
+@Component
+public class LevenshteinDistanceCache {
+
+    @Autowired
+    private ClinicalAttributeMetadataCache clinicalAttributesCache;
+    
+    private Map<ClinicalAttributeMetadata, Map<String, Integer>> levenshteinDistanceCache = new HashMap<ClinicalAttributeMetadata, Map<String, Integer>>();
+    
+    private static final Logger logger = LoggerFactory.getLogger(LevenshteinDistanceCache.class);
+
+    public boolean containsClinicalAttribute(ClinicalAttributeMetadata clinicalAttributeMetadata) {
+        return levenshteinDistanceCache.containsKey(clinicalAttributeMetadata);
+    }
+
+    public void addClinicalAttribute(ClinicalAttributeMetadata clinicalAttributeMetadata) {
+        this.levenshteinDistanceCache.put(clinicalAttributeMetadata, new HashMap<String, Integer>());
+    }
+
+    public boolean containsClinicalAttributeToSearchTermMapping(ClinicalAttributeMetadata clinicalAttributeMetadata, String searchTerm) {
+        return levenshteinDistanceCache.get(clinicalAttributeMetadata).containsKey(searchTerm);
+    }
+    
+    public void addClinicalAttributeToSearchTermMapping(ClinicalAttributeMetadata clinicalAttributeMetadata, String searchTerm) {
+        this.levenshteinDistanceCache.get(clinicalAttributeMetadata).put(searchTerm, clinicalAttributeMetadata.levenshteinDistanceFromSearchTerm(searchTerm));
+    }
+    
+    public Integer getLevenshteinDistanceForMapping(ClinicalAttributeMetadata clinicalAttributeMetadata, String searchTerm) {
+        return levenshteinDistanceCache.get(clinicalAttributeMetadata).get(searchTerm);
+    }
+
+    public void resetCache() {
+        logger.info("resetCache(): recalculating Levenshtein Distances with refreshed CDD attributes");
+        Map<String, ClinicalAttributeMetadata> defaultClinicalAttributeCache = clinicalAttributesCache.getClinicalAttributeMetadata();
+        Map<ClinicalAttributeMetadata, List<String>> searchTermMappingsToRemove = new HashMap<ClinicalAttributeMetadata, List<String>>();
+        List<ClinicalAttributeMetadata> clinicalAttributeMetadataToRemove = new ArrayList<ClinicalAttributeMetadata>();
+        
+        for (ClinicalAttributeMetadata cachedClinicalAttributeMetadata : levenshteinDistanceCache.keySet()) {
+            ClinicalAttributeMetadata currentClinicalAttributeMetadata;
+            // during cache refresh - remove levenshtein distance mappings if the clinical attribute has been removed from CDD
+            if (!defaultClinicalAttributeCache.containsKey(cachedClinicalAttributeMetadata.getColumnHeader())) {
+                clinicalAttributeMetadataToRemove.add(cachedClinicalAttributeMetadata);
+                continue; 
+            } else {
+                currentClinicalAttributeMetadata = defaultClinicalAttributeCache.get(cachedClinicalAttributeMetadata.getColumnHeader());
+            }
+            // recalculate and set levenshtein distances to new values (calculated from updated displays, descriptions, etc...) 
+            // remove search term mappings which are no longer contained in the display, description, etc...
+            for (String searchTerm : levenshteinDistanceCache.get(cachedClinicalAttributeMetadata).keySet()) {
+                if (!currentClinicalAttributeMetadata.containsSearchTerm(searchTerm)) {
+                    if(!searchTermMappingsToRemove.containsKey(cachedClinicalAttributeMetadata)) {
+                        searchTermMappingsToRemove.put(cachedClinicalAttributeMetadata, new ArrayList<String>());
+                    }
+                    searchTermMappingsToRemove.get(cachedClinicalAttributeMetadata).add(searchTerm);
+                    continue;
+                }                   
+                Integer levenshteinDistance = currentClinicalAttributeMetadata.levenshteinDistanceFromSearchTerm(searchTerm);
+                levenshteinDistanceCache.get(cachedClinicalAttributeMetadata).put(searchTerm, levenshteinDistance);
+            }
+        }
+        for (ClinicalAttributeMetadata clinicalAttributeMetadata : clinicalAttributeMetadataToRemove) {
+            levenshteinDistanceCache.remove(clinicalAttributeMetadata);
+        }
+        for (ClinicalAttributeMetadata clinicalAttributeMetadata : searchTermMappingsToRemove.keySet()) {
+            for (String searchTerm : searchTermMappingsToRemove.get(clinicalAttributeMetadata)) {
+                levenshteinDistanceCache.get(clinicalAttributeMetadata).remove(searchTerm);
+            }
+        }
+    }
+} 

--- a/src/main/java/org/cbioportal/cdd/web/ClinicalDataDictionaryController.java
+++ b/src/main/java/org/cbioportal/cdd/web/ClinicalDataDictionaryController.java
@@ -87,6 +87,25 @@ public class ClinicalDataDictionaryController {
         return clinicalAttributesService.getMetadataByColumnHeaders(cancerStudyName, columnHeaders);
     }
 
+    @ApiOperation(value = "Get metadata for a search term", response = ClinicalAttributeMetadata.class, responseContainer = "List")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Successfully retrieved list of clinical attributes matching search term"),
+        @ApiResponse(code = 400, message = "Bad request"),
+        @ApiResponse(code = 404, message = "Could not find any clinical attributes matching search term"),
+        @ApiResponse(code = 503, message = "Clinical attribute metadata source unavailable")
+        }
+    )
+    @RequestMapping(method = RequestMethod.POST, value="/search", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Iterable<ClinicalAttributeMetadata> getClinicalAttributeMetadataBySearchTerms(
+        @ApiParam(value = "Attribute type e.g. PATIENT or SAMPLE")
+        @RequestParam(value = "attributeType", required = false) String attributeType, 
+        @ApiParam(value = "Inclusive search - all search terms must be present when searching")
+        @RequestParam(value = "inclusiveSearch", defaultValue = "false", required = true) boolean inclusiveSearch, 
+        @ApiParam(value = "List of search terms that may be present in the description, display name, or column header. For example: [\"TMB\", \"mutation burden\"]")
+        @RequestBody(required = true) List<String> searchTerms) {
+        return clinicalAttributesService.getMetadataBySearchTerms(searchTerms, attributeType, inclusiveSearch);
+    }
+
     @ApiOperation(value = "Get metadata for one clinical attribute", response = ClinicalAttributeMetadata.class)
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Successfully retrieved clinical attribute"),

--- a/src/test/java/org/cbioportal/cdd/ClinicalDataDictionaryTestConfig.java
+++ b/src/test/java/org/cbioportal/cdd/ClinicalDataDictionaryTestConfig.java
@@ -20,6 +20,7 @@ import org.mockito.Mockito;
 import org.cbioportal.cdd.model.ClinicalAttributeMetadata;
 import org.cbioportal.cdd.repository.ClinicalAttributeMetadataRepository;
 import org.cbioportal.cdd.service.internal.ClinicalAttributeMetadataCache;
+import org.cbioportal.cdd.service.internal.LevenshteinDistanceCache;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,6 +32,11 @@ public class ClinicalDataDictionaryTestConfig {
     public ClinicalAttributeMetadataRepository clinicalAttributesRepository() {
         ClinicalAttributeMetadataRepository clinicalAttributesRepository = Mockito.mock(ClinicalAttributeMetadataRepository.class);
         return clinicalAttributesRepository;
+    }
+
+    @Bean
+    public LevenshteinDistanceCache levenshteinDistanceCache() {
+        return new LevenshteinDistanceCache();
     }
 
     public void resetWorkingClinicalAttributesRepository(ClinicalAttributeMetadataRepository clinicalAttributesRepository) {


### PR DESCRIPTION
Use Case: searching for a term. TopBraid search is not ideal because query only applies to `preferred label` and must start from beginning of the string.

**i.e** to query `TMB_MUTATION_BURDEN`, must start query with `TMB_MU...`
The new endpoint will return `TMB_MUTATION_BURDEN` with query `mutation burden` 

- takes in a list of search terms - returns list of attributes where search term
is present in any one of the following (description, column header, display name)
- option to filter results by attribute type (`PATIENT`, `SAMPLE`)
- option for inclusive search (all search terms must be present)
- list returned is ordered by levenshtein distance (so most similar matches should return first)

**i.e search** [`necrosis`]

**Returns  ordered list**: 
[`NECROSIS`, `HISTO_GEO_NECROSIS`, `PERCENTAGE_NECROSIS`, `TUMOR_TOTAL_NECROSIS`, `RELAPSE_PERCENT_NECROSIS`, `HISTOLOGIC_RESPONSE`]

*`HISTOLOGIC_RESPONSE` included because description is "Histologic Response Post Neoadjuvant Therapy **Necrosis** Percent Category. Stage 1/2 (0-90 % **necrosis**), Stage 3/4 (91-100 % **necrosis**)"

**i.e inclusive search** [`necrosis`, `percent`]

**Returns ordered list**:
[`PERCENTAGE_NECROSIS`, `RELAPSE_PERCENT_NECROSIS`, `HISTOLOGIC_RESPONSE`]

new unit tests for testing search functionality

link to test CDD:  http://dashi-dev.cbio.mskcc.org:8080/cdd-test/swagger-ui.html#!/clinical-data-dictionary-controller/getClinicalAttributeMetadataBySearchTermsUsingPOST