### PR TITLE
EHCache Configuration Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,21 +175,32 @@
         </includes>
       </resource>
     </resources>
+    <!-- enable filtering on test resources -->
+    <testResources>
+      <testResource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+            <include>**/application.properties</include>
+            <include>**/ehcache.xml</include>
+        </includes>
+      </testResource>
+    </testResources>
     <plugins>
-        <!-- maven resources plugin
-            Note: Delimiter configuration is explicitly declared
-            due to this project being a spring boot application,
-            which, since 1.7 expects placeholders in XML / other
-            configuration files to begin and end with '@' isntead
-            of ${...}. Also note that this specification does not
-            affect the injected properties in Java classes which
-            can still be autowired in with ${...} regardless.
-        -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>2.6</version>
-          <configuration>
+      <!-- maven resources plugin
+        Note: Delimiter configuration is explicitly declared
+        due to this project being a spring boot application,
+        which, since 1.7 expects placeholders in XML / other
+        configuration files to begin and end with '@' isntead
+        of ${...}. Also note that this specification does not
+        affect the injected properties in Java classes which
+        can still be autowired in with ${...} regardless.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
           <delimiters>
             <delimiter>${*}</delimiter>
           </delimiters>
@@ -214,7 +225,17 @@
           </webResources>
         </configuration>
       </plugin>
+<!--      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>-->
     </plugins>
   </build>
-
 </project>

--- a/src/main/java/org/cbioportal/cdd/config/CDDAppConfig.java
+++ b/src/main/java/org/cbioportal/cdd/config/CDDAppConfig.java
@@ -19,13 +19,13 @@
 package org.cbioportal.cdd.config;
 
 import java.io.File;
-import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.jcache.JCacheCacheManager;
 import org.springframework.cache.jcache.JCacheManagerFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.ResourceUtils;
 
 /**
  *
@@ -35,16 +35,21 @@ import org.springframework.core.io.ClassPathResource;
 @EnableCaching
 public class CDDAppConfig {
 
+    @Value("${ehcache.persistence.path}")
+    private String ehcachePersistencePath;
+
     @Bean
-    public JCacheCacheManager cacheManager() throws IOException {
-        JCacheCacheManager cacheManager = new JCacheCacheManager();
-        cacheManager.setCacheManager(ehCacheCacheManager().getObject());
-        return cacheManager;
-    }
-    @Bean
-    public JCacheManagerFactoryBean ehCacheCacheManager() throws IOException {
+    public JCacheManagerFactoryBean jCacheManagerFactory() throws Exception {
+        File file = ResourceUtils.getFile("classpath:ehcache.xml");
         JCacheManagerFactoryBean factory = new JCacheManagerFactoryBean();
-        factory.setCacheManagerUri(new File("/Users/ochoaa/cbio-projects/clinical-data-dictionary/src/main/resources/ehcache.xml").toURI());
+        factory.setCacheManagerUri(file.getAbsoluteFile().toURI());
         return factory;
+    }
+
+    @Bean
+    public JCacheCacheManager jCacheCacheManager() throws Exception {
+        JCacheCacheManager jCacheCacheManager = new JCacheCacheManager();
+        jCacheCacheManager.setCacheManager(jCacheManagerFactory().getObject());
+        return jCacheCacheManager;
     }
 }

--- a/src/main/java/org/cbioportal/cdd/model/ClinicalAttributeMetadata.java
+++ b/src/main/java/org/cbioportal/cdd/model/ClinicalAttributeMetadata.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.annotations.ApiModelProperty;
+import java.io.Serializable;
 import java.util.*;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -39,7 +40,7 @@ import org.apache.commons.lang3.StringUtils;
     "attribute_type",
     "priority",
 })
-public class ClinicalAttributeMetadata {
+public class ClinicalAttributeMetadata implements Serializable {
 
     private String studyId;
     @ApiModelProperty(value = "The column header")
@@ -261,9 +262,9 @@ public class ClinicalAttributeMetadata {
     public boolean containsSearchTerm(String searchTerm) {
         return (StringUtils.containsIgnoreCase(this.columnHeader, searchTerm) ||
             StringUtils.containsIgnoreCase(this.displayName, searchTerm) ||
-            StringUtils.containsIgnoreCase(this.description, searchTerm));   
+            StringUtils.containsIgnoreCase(this.description, searchTerm));
     }
-    
+
     public boolean containsAllSearchTerms(List<String> searchTerms) {
         for (String searchTerm : searchTerms) {
             if (!containsSearchTerm(searchTerm)) {
@@ -272,12 +273,12 @@ public class ClinicalAttributeMetadata {
         }
         return true;
     }
-                
+
     public Integer levenshteinDistanceFromSearchTerm(String searchTerm) {
         Integer levenshteinDistance = Integer.MAX_VALUE;
         if (StringUtils.containsIgnoreCase(this.columnHeader, searchTerm)) {
             levenshteinDistance = Math.min(levenshteinDistance, StringUtils.getLevenshteinDistance(searchTerm, this.columnHeader));
-        } 
+        }
         if (StringUtils.containsIgnoreCase(this.displayName, searchTerm)) {
             levenshteinDistance = Math.min(levenshteinDistance, StringUtils.getLevenshteinDistance(searchTerm, this.displayName));
         }
@@ -285,9 +286,9 @@ public class ClinicalAttributeMetadata {
             levenshteinDistance = Math.min(levenshteinDistance, StringUtils.getLevenshteinDistance(searchTerm, this.description));
         }
         return levenshteinDistance;
-    } 
+    }
 
     public boolean matchesAttributeType(String attributeType) {
         return attributeType == null || attributeType.toUpperCase().equals(this.attributeType);
-    }   
+    }
 }

--- a/src/main/java/org/cbioportal/cdd/repository/topbraid/TopBraidException.java
+++ b/src/main/java/org/cbioportal/cdd/repository/topbraid/TopBraidException.java
@@ -18,7 +18,9 @@
 
 package org.cbioportal.cdd.repository.topbraid;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  *
@@ -26,10 +28,10 @@ import org.apache.log4j.Logger;
  **/
 public class TopBraidException extends RuntimeException {
 
-    private final static Logger logger = Logger.getLogger(TopBraidException.class);
+    private final static Logger logger = LoggerFactory.getLogger(TopBraidException.class);
 
     public TopBraidException(String message, Throwable cause) {
         super(message, cause);
         logger.error(message + ": " + cause + " (Check that authentication is working)");
-    }   
+    }
 }

--- a/src/main/java/org/cbioportal/cdd/repository/topbraid/TopBraidRepository.java
+++ b/src/main/java/org/cbioportal/cdd/repository/topbraid/TopBraidRepository.java
@@ -18,11 +18,9 @@
 
 package org.cbioportal.cdd.repository.topbraid;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.ArrayList;
-
-import org.apache.log4j.Logger;
+import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +28,6 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -47,7 +44,7 @@ import org.springframework.web.client.RestTemplate;
 @Repository
 public abstract class TopBraidRepository<T> {
 
-    private final static Logger logger = Logger.getLogger(TopBraidRepository.class);
+    private final static Logger logger = LoggerFactory.getLogger(TopBraidRepository.class);
 
     @Value("${topbraid.url}")
     private String topBraidURL;
@@ -70,7 +67,7 @@ public abstract class TopBraidRepository<T> {
         // the default supported types for MappingJackson2HttpMessageConverter are:
         //   application/json and application/*+json
         // our response content type is application/sparql-results+json-simple
-        // NOTE: if the response content type was one of the default types we 
+        // NOTE: if the response content type was one of the default types we
         //   would not have to add the message converter to the rest template
         MappingJackson2HttpMessageConverter messageConverter = new MappingJackson2HttpMessageConverter();
         messageConverter.setSupportedMediaTypes(Collections.singletonList(

--- a/src/main/java/org/cbioportal/cdd/repository/topbraid/TopBraidSessionConfiguration.java
+++ b/src/main/java/org/cbioportal/cdd/repository/topbraid/TopBraidSessionConfiguration.java
@@ -18,22 +18,18 @@
 
 package org.cbioportal.cdd.repository.topbraid;
 
-import java.net.URI;
-import java.util.Calendar;
 import java.util.List;
-import java.util.Map;
 
-import org.apache.log4j.Logger;
-import org.apache.http.client.CookieStore;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.cookie.Cookie;
-import org.apache.http.impl.cookie.BasicClientCookie;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -46,7 +42,7 @@ import org.springframework.http.HttpStatus;
 @Configuration
 public class TopBraidSessionConfiguration {
 
-    private final static Logger logger = Logger.getLogger(TopBraidSessionConfiguration.class);
+    private final static Logger logger = LoggerFactory.getLogger(TopBraidSessionConfiguration.class);
 
     @Value("${topbraid.url}")
     private String topBraidURL;
@@ -109,7 +105,7 @@ public class TopBraidSessionConfiguration {
 
             CloseableHttpClient client = HttpClients.createDefault();
             CloseableHttpResponse response = client.execute(new HttpHead(url), context);
-            StatusLine statusLine = response.getStatusLine(); 
+            StatusLine statusLine = response.getStatusLine();
             if (statusLine.getStatusCode() != HttpStatus.OK.value()) {
                 logger.error("Response status: '" + statusLine + "'");
                 return null;
@@ -123,7 +119,7 @@ public class TopBraidSessionConfiguration {
                     return cookie;
                 }
             }
-            
+
             // close stuff
             client.close();
             response.close();

--- a/src/main/java/org/cbioportal/cdd/service/exception/FailedCacheRefreshException.java
+++ b/src/main/java/org/cbioportal/cdd/service/exception/FailedCacheRefreshException.java
@@ -22,8 +22,8 @@ public class FailedCacheRefreshException extends RuntimeException {
 
     private static final Logger logger = LoggerFactory.getLogger(FailedCacheRefreshException.class);
 
-    public FailedCacheRefreshException(String error) {
-        super(error);
+    public FailedCacheRefreshException(String error, Throwable e) {
+        super(error, e);
         logger.error(error);
     }
 

--- a/src/main/java/org/cbioportal/cdd/service/internal/ClinicalAttributeMetadataCache.java
+++ b/src/main/java/org/cbioportal/cdd/service/internal/ClinicalAttributeMetadataCache.java
@@ -61,7 +61,7 @@ public class ClinicalAttributeMetadataCache {
     // if overridesCache is null it means we could not populate it, there was an error
     private static HashMap<String, Map<String, ClinicalAttributeMetadata>> overridesCache;
     private static Date dateOfLastCacheRefresh = new Date();
-    
+
     public static final Integer MAXIMUM_CACHE_AGE_IN_DAYS = 3;
     private static final Logger logger = LoggerFactory.getLogger(ClinicalAttributeMetadataCache.class);
 
@@ -71,7 +71,7 @@ public class ClinicalAttributeMetadataCache {
     public Date getDateOfLastCacheRefresh() {
         return dateOfLastCacheRefresh;
     }
-    
+
     public void setDateOfLastCacheRefresh(Date date) {
         this.dateOfLastCacheRefresh = date;
     }
@@ -89,7 +89,7 @@ public class ClinicalAttributeMetadataCache {
         }
         return null;
     }
-    
+
     private void sendStaleCacheSlackNotification() {
         String payload = "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"*URGENT: CDD Error* - an attempt to refresh an outdated or null cache failed.\", \"icon_emoji\": \":rotating_light:\"}";
         StringEntity entity = new StringEntity(payload, ContentType.APPLICATION_FORM_URLENCODED);
@@ -135,7 +135,7 @@ public class ClinicalAttributeMetadataCache {
             } else {
                 logger.error("resetCache(): failed to pull overrides from repository");
             }
-            throw new FailedCacheRefreshException("Failed to refresh cache");
+            throw new FailedCacheRefreshException("Failed to refresh cache", e);
         }
         HashMap<String, ClinicalAttributeMetadata> latestClinicalAttributeMetadataCache = new HashMap<String, ClinicalAttributeMetadata>();
         for (ClinicalAttributeMetadata clinicalAttributeMetadata : latestClinicalAttributeMetadata) {
@@ -160,7 +160,7 @@ public class ClinicalAttributeMetadataCache {
         dateOfLastCacheRefresh = dateOfCurrentCacheRefresh;
         logger.info("resetCache(): cache last refreshed on: " + dateOfLastCacheRefresh.toString());
     }
-        
+
     public boolean cacheIsStale() {
         ZonedDateTime currentDate = ZonedDateTime.now();
         ZonedDateTime dateOfCacheExpiration = currentDate.plusDays(- MAXIMUM_CACHE_AGE_IN_DAYS);
@@ -170,7 +170,7 @@ public class ClinicalAttributeMetadataCache {
             return false;
         }
     }
-    
+
     private void fillOverrideAttributeWithDefaultValues(ClinicalAttributeMetadata overrideClinicalAttribute, ClinicalAttributeMetadata defaultClinicalAttribute) {
         logger.debug("fillOverrideAttributeWithDefaultValues()");
         if (Strings.isNullOrEmpty(overrideClinicalAttribute.getDisplayName())) {

--- a/src/main/java/org/cbioportal/cdd/service/internal/ClinicalDataDictionaryServiceImpl.java
+++ b/src/main/java/org/cbioportal/cdd/service/internal/ClinicalDataDictionaryServiceImpl.java
@@ -15,14 +15,7 @@
 
 package org.cbioportal.cdd.service.internal;
 
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import org.cbioportal.cdd.model.CancerStudy;
 import org.cbioportal.cdd.model.ClinicalAttributeMetadata;
 import org.cbioportal.cdd.service.ClinicalDataDictionaryService;
@@ -33,8 +26,6 @@ import org.cbioportal.cdd.service.exception.FailedCacheRefreshException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.jcache.JCacheCacheManager;
 import org.springframework.stereotype.Service;
 
 /**

--- a/src/main/java/org/cbioportal/cdd/util/CacheEventLogger.java
+++ b/src/main/java/org/cbioportal/cdd/util/CacheEventLogger.java
@@ -18,21 +18,22 @@
 
 package org.cbioportal.cdd.util;
 
-import org.apache.log4j.Logger;
 import org.ehcache.event.CacheEvent;
 import org.ehcache.event.CacheEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 /**
  *
  * @author ochoaa
  */
 public class CacheEventLogger implements CacheEventListener<Object, Object> {
 
-    private static Logger LOG = Logger.getLogger(CacheEventLogger.class);
+    private final static Logger logger = LoggerFactory.getLogger(CacheEventLogger.class);
 
     @Override
     public void onEvent(CacheEvent cacheEvent) {
-        if (LOG.isInfoEnabled()) {
-            LOG.info("CACHE_EVENT:\n" +
+        if (logger.isInfoEnabled()) {
+            logger.info("CACHE_EVENT:\n" +
                      "\tTYPE: " + cacheEvent.getType() + "\n" +
                      "\tKEY: " + cacheEvent.getKey() + "\n" +
                      "\tVALUE: " + cacheEvent.getNewValue() + "\n" +

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -4,7 +4,6 @@ topbraid.password=
 
 slack.url=
 
-spring.cache.jcache.config=
 ehcache.persistence.path=
 ehcache.enable.statistics=false
 ehcache.clinicalAttributeMetadataByStudyCache.maxBytesLocalDiskUnits=

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -8,16 +8,13 @@
     http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
     http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
     <ehcache:service>
-      <!-- TODO: INJECT PROPERTY WITH MVN FILTERING
-      <jcache:defaults enable-management="true" enable-statistics="${ehcache.enable.statistics}"/-->
-      <jcache:defaults enable-management="true" enable-statistics="true"/>
+      <jcache:defaults enable-management="true" enable-statistics="${ehcache.enable.statistics}"/>
     </ehcache:service>
-
-    <!-- TODO: INJECT PROPERTY WITH MVN FILTERING
-    <ehcache:persistence directory="${ehcache.persistence.path}"/-->
-    <ehcache:persistence directory="/Users/ochoaa/tmp/ehcache"/>
+    <ehcache:persistence directory="${ehcache.persistence.path}"/>
 
     <ehcache:cache alias="clinicalAttributeMetadataEHCache">
+      <ehcache:key-type>java.lang.String</ehcache:key-type>
+      <ehcache:value-type>java.util.ArrayList</ehcache:value-type>
       <ehcache:listeners>
         <ehcache:listener>
           <ehcache:class>org.cbioportal.cdd.util.CacheEventLogger</ehcache:class>
@@ -28,13 +25,13 @@
         </ehcache:listener>
       </ehcache:listeners>
       <ehcache:resources>
-        <!-- TODO: INJECT PROPERTIES WITH MVN FILTERING
-        <ehcache:disk unit="${ehcache.clinicalAttributeMetadataEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.clinicalAttributeMetadataEHCache.maxBytesLocalDisk}</ehcache:disk -->
-        <ehcache:disk unit="MB" persistent="true">100</ehcache:disk>
+        <ehcache:disk unit="${ehcache.clinicalAttributeMetadataEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.clinicalAttributeMetadataEHCache.maxBytesLocalDisk}</ehcache:disk>
       </ehcache:resources>
     </ehcache:cache>
 
     <ehcache:cache alias="clinicalAttributeMetadataOverridesEHCache">
+      <ehcache:key-type>java.lang.String</ehcache:key-type>
+      <ehcache:value-type>java.util.HashMap</ehcache:value-type>
       <ehcache:listeners>
         <ehcache:listener>
           <ehcache:class>org.cbioportal.cdd.util.CacheEventLogger</ehcache:class>
@@ -45,9 +42,7 @@
         </ehcache:listener>
       </ehcache:listeners>
       <ehcache:resources>
-        <!-- TODO: INJECT PROPERTIES WITH MVN FILTERING
-        <ehcache:disk unit="${ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDisk}</ehcache:disk -->
-        <ehcache:disk unit="MB" persistent="true">100</ehcache:disk>
+        <ehcache:disk unit="${ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDisk}</ehcache:disk>
       </ehcache:resources>
     </ehcache:cache>
 

--- a/src/test/java/org/cbioportal/cdd/ClinicalDataDictionaryTest.java
+++ b/src/test/java/org/cbioportal/cdd/ClinicalDataDictionaryTest.java
@@ -15,26 +15,20 @@
 
 package org.cbioportal.cdd;
 
+import org.cbioportal.cdd.repository.ClinicalAttributeMetadataRepository;
+import org.cbioportal.cdd.service.internal.ClinicalAttributeMetadataCache;
+import org.cbioportal.cdd.service.exception.*;
+import org.cbioportal.cdd.config.CDDAppConfig;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Calendar;
-import java.util.Date;
-import org.cbioportal.cdd.config.CDDAppConfig;
-
-import org.cbioportal.cdd.repository.ClinicalAttributeMetadataRepository;
-import org.cbioportal.cdd.service.internal.ClinicalAttributeMetadataCache;
-import org.cbioportal.cdd.service.internal.LevenshteinDistanceCache;
-import org.cbioportal.cdd.service.exception.*;
-
+import java.util.*;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertFalse;
 import org.junit.runner.RunWith;
 import org.junit.Test;
 import org.junit.Before;
@@ -44,7 +38,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.cache.jcache.JCacheCacheManager;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -66,13 +59,6 @@ public class ClinicalDataDictionaryTest {
     @Autowired
     private ClinicalAttributeMetadataCache clinicalAttributesCache;
 
-    @Autowired
-    private JCacheCacheManager cacheManager;
-
-    // TODO: REMOVE IF UNUSED
-//    @Autowired
-//    private LevenshteinDistanceCache levenshteinDistanceCache;
-
     @Before
     // make sure repository is working version before each test
     public void resetToWorkingRepository() {
@@ -93,14 +79,14 @@ public class ClinicalDataDictionaryTest {
         assertThat(responseJSON.size(), equalTo(5));
         assertThat(response.getBody(), containsString("{\"column_header\":\"LAST_STATUS\",\"display_name\":\"Last Status\",\"description\":\"Last Status.\",\"datatype\":\"STRING\",\"attribute_type\":\"PATIENT\",\"priority\":\"1\"}"));
     }
-    
+
     @Test
     public void getClinicalAttributeMetadataBySearchTermsTest() throws Exception {
         //test we can get a list of clinical attributes by search term
         List<String> searchTerms = Arrays.asList("Stage");
         ResponseEntity<String> response = restTemplate.postForEntity("/api/search", searchTerms, String.class);
         assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
-        
+
         ObjectMapper mapper = new ObjectMapper();
         JsonNode responseJSON = mapper.readTree(response.getBody());
         assertThat(responseJSON.size(), equalTo(2));
@@ -108,11 +94,11 @@ public class ClinicalDataDictionaryTest {
             + "\"Extent of the distant metastasis for the cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.\",\"datatype\":\"STRING\",\"attribute_type\":\"PATIENT\",\"priority\":\"1\"}"));
         assertThat(response.getBody(), containsString("{\"column_header\":\"DISEASE_STAGE\",\"display_name\":\"Disease Stage\",\"description\":"
             + "\"Disease Stage\",\"datatype\":\"STRING\",\"attribute_type\":\"SAMPLE\",\"priority\":\"1\"}"));
-        
+
         searchTerms = Arrays.asList("Stage", "bone marrow");
         response = restTemplate.postForEntity("/api/search", searchTerms, String.class);
         assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
-        
+
         responseJSON = mapper.readTree(response.getBody());
         assertThat(responseJSON.size(), equalTo(3));
         assertThat(response.getBody(), containsString("{\"column_header\":\"CLIN_M_STAGE\",\"display_name\":\"Neoplasm American Joint Committee on Cancer Clinical Distant Metastasis M Stage\",\"description\":"
@@ -129,7 +115,7 @@ public class ClinicalDataDictionaryTest {
         List<String> searchTerms = Arrays.asList("Stage");
         ResponseEntity<String> response = restTemplate.postForEntity("/api/search?attributeType=PATIENT", searchTerms, String.class);
         assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
-        
+
         ObjectMapper mapper = new ObjectMapper();
         JsonNode responseJSON = mapper.readTree(response.getBody());
         assertThat(responseJSON.size(), equalTo(1));
@@ -166,9 +152,9 @@ public class ClinicalDataDictionaryTest {
             clinicalAttributesCache.resetCache();
         }
         assertThat(clinicalAttributesCache.getDateOfLastCacheRefresh().toString(), equalTo(validDateOfLastCacheRefresh.toString()));
- 
+
         // test condition where cache is stale
-        // set cache age to a invalid age (current date - MAXIMUM_CACHE_AGE_IN_DAYS - 1)  
+        // set cache age to a invalid age (current date - MAXIMUM_CACHE_AGE_IN_DAYS - 1)
         // cache is stale so resetCache should be called -- cache age should change
         currentDate.add(Calendar.DATE, -2);
         Date expiredDateOfLastCacheRefresh = currentDate.getTime();
@@ -178,10 +164,10 @@ public class ClinicalDataDictionaryTest {
         }
         assertThat(clinicalAttributesCache.getDateOfLastCacheRefresh().toString(), not(equalTo(validDateOfLastCacheRefresh.toString())));
     }
- 
+
     @Test(expected = FailedCacheRefreshException.class)
     public void failedCacheRefreshTest() throws Exception {
-        // resetting cache with a broken repository should throw a FailedCacheRefreshException 
+        // resetting cache with a broken repository should throw a FailedCacheRefreshException
         ClinicalDataDictionaryTestConfig config = new ClinicalDataDictionaryTestConfig();
         config.resetNotWorkingClinicalAttributesRepository(clinicalAttributesRepository);
         clinicalAttributesCache.resetCache();

--- a/src/test/java/org/cbioportal/cdd/ClinicalDataDictionaryTestConfig.java
+++ b/src/test/java/org/cbioportal/cdd/ClinicalDataDictionaryTestConfig.java
@@ -19,9 +19,6 @@ import java.util.*;
 import org.mockito.Mockito;
 import org.cbioportal.cdd.model.ClinicalAttributeMetadata;
 import org.cbioportal.cdd.repository.ClinicalAttributeMetadataRepository;
-import org.cbioportal.cdd.service.internal.ClinicalAttributeMetadataCache;
-import org.cbioportal.cdd.service.internal.LevenshteinDistanceCache;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -33,11 +30,6 @@ public class ClinicalDataDictionaryTestConfig {
         ClinicalAttributeMetadataRepository clinicalAttributesRepository = Mockito.mock(ClinicalAttributeMetadataRepository.class);
         return clinicalAttributesRepository;
     }
-    // TODO: REMOVE IF UNUSED
-//    @Bean
-//    public LevenshteinDistanceCache levenshteinDistanceCache() {
-//        return new LevenshteinDistanceCache();
-//    }
 
     public void resetWorkingClinicalAttributesRepository(ClinicalAttributeMetadataRepository clinicalAttributesRepository) {
         Mockito.reset(clinicalAttributesRepository);


### PR DESCRIPTION
Loads successfully from ehcache.xml
ehcache.xml gets packed into war under WEB-INF/classes
EHCache is populated on first calls to @Cacheable methods but not subsequent calls to these methods (expected behavior)

TO-DO:
- [x] Need to inject properties with maven from application.properties to ehcache.xml. Placeholders are not being substituted correctly.
- [ ] Add unit tests
- [ ] Add integration tests (?)
- [ ] Confirm that if topbraid is down, we are actually loading data from EHCache persistence directory
- [ ] Confirm that EHCache persists between tomcat restarts (restarting tomcat does not delete the cache)
- [ ] Support ability to forcefully wipe the EHCache if we wish so that we can force a data update from TopBraid
- [ ] resolve dependency / cache manager conflicts with Tomcat's configured cache management (i.e., cdd uses JCacheCacheManager and does not try to use Redisson cache manager - this was an issue when deploying on dashi-dev `schultz-tomcat`)

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>