### PR TITLE
Exclude spring-boot-starter-logging 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
           <groupId>org.hibernate</groupId>
           <artifactId>hibernate-validator</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
To fix: `Caused by: java.lang.IllegalArgumentException: LoggerFactory is not a Logback LoggerContext but Logback is on the classpath. Either remove Logback or the competing implementation (class org.slf4j.helpers.NOPLoggerFactory loaded from file:/srv/www/schultz-tomcat/apache-tomcat-8.5.29/webapps/cdd/WEB-INF/lib/slf4j-api-1.7.26.jar). If you are using WebLogic you will need to add 'org.slf4j' to prefer-application-packages in WEB-INF/weblogic.xml: org.slf4j.helpers.NOPLoggerFactory`