### PR TITLE
My ehcache test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,6 @@
           <groupId>org.hibernate</groupId>
           <artifactId>hibernate-validator</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-logging</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/src/main/java/org/cbioportal/cdd/repository/topbraid/ClinicalAttributeMetadataRepositoryTopBraidImpl.java
+++ b/src/main/java/org/cbioportal/cdd/repository/topbraid/ClinicalAttributeMetadataRepositoryTopBraidImpl.java
@@ -88,8 +88,6 @@ public class ClinicalAttributeMetadataRepositoryTopBraidImpl extends TopBraidRep
         try {
             logger.info("CACHING SPARQL QUERY getClinicalAttributeMetadata");
             ArrayList<ClinicalAttributeMetadata> list = new ArrayList<ClinicalAttributeMetadata>(super.query(GET_CLINICAL_ATTRIBUTES_SPARQL_QUERY_STRING, new ParameterizedTypeReference<List<ClinicalAttributeMetadata>>(){}));
-            jCacheCacheManager.getCache("clinicalAttributeMetadataEHCache").put(GET_OVERRIDES_SPARQL_QUERY_STRING, list);
-
             return list;
         } catch (TopBraidException e) {
             logger.error("Problem connecting to TopBraid");
@@ -109,8 +107,6 @@ public class ClinicalAttributeMetadataRepositoryTopBraidImpl extends TopBraidRep
                 }
                 overridesStudyMap.get(clinicalAttributeMetadata.getStudyId()).add(clinicalAttributeMetadata);
             }
-            jCacheCacheManager.getCache("clinicalAttributeMetadataOverridesEHCache").put(GET_OVERRIDES_SPARQL_QUERY_STRING, overridesStudyMap);
-
             return overridesStudyMap;
         } catch (TopBraidException e) {
             logger.error("Problem connecting to TopBraid");

--- a/src/main/java/org/cbioportal/cdd/service/internal/ClinicalAttributeMetadataCache.java
+++ b/src/main/java/org/cbioportal/cdd/service/internal/ClinicalAttributeMetadataCache.java
@@ -45,6 +45,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.context.event.EventListener;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 
 /**
  * @author Robert Sheridan, Avery Wang, Manda Wilson
@@ -104,7 +106,7 @@ public class ClinicalAttributeMetadataCache {
         }
     }
 
-    @PostConstruct // call when constructed
+    @EventListener(ApplicationReadyEvent.class)
     @Scheduled(cron="0 */10 * * * *") // call every 10 minutes
     private void validateAndResetCache() {
         if (cacheIsStale() || clinicalAttributeCache == null || overridesCache == null) {

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -25,6 +25,7 @@
         </ehcache:listener>
       </ehcache:listeners>
       <ehcache:resources>
+        <ehcache:heap unit="B">1</ehcache:heap>
         <ehcache:disk unit="${ehcache.clinicalAttributeMetadataEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.clinicalAttributeMetadataEHCache.maxBytesLocalDisk}</ehcache:disk>
       </ehcache:resources>
     </ehcache:cache>
@@ -42,6 +43,7 @@
         </ehcache:listener>
       </ehcache:listeners>
       <ehcache:resources>
+        <ehcache:heap unit="B">1</ehcache:heap>
         <ehcache:disk unit="${ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDisk}</ehcache:disk>
       </ehcache:resources>
     </ehcache:cache>


### PR DESCRIPTION
No longer using PostConstruct to populate in memory working cache. (@PostConstruct incompatible with @Cacheable).
Letting @Cachable handle all caching - remove manual interactions. 
Fixes to CacheManager to fix overlaps with Redisson in tomcat (along with lock issue) 