### PR TITLE
Backing up Ehcache and then pulling from backup automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ logs/
 # config files
 application.properties
 log4j.properties
-src/test/resources/ehcache.xml
 
 # target directories
 target/

--- a/integration-tests/set_application_properties.sh
+++ b/integration-tests/set_application_properties.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+JENKINS_USER_HOME_DIRECTORY=/var/lib/jenkins
+JENKINS_PROPERTIES_DIRECTORY=$JENKINS_USER_HOME_DIRECTORY/pipelines-configuration/properties
+JENKINS_CDD_PROPERTIES_DIRECTORY=$JENKINS_PROPERTIES_DIRECTORY/clinical-data-dictionary
+
+# CDD_DIRECTORY is starting directory - location on jenkins machine where github repo is cloned
+CDD_DIRECTORY="$(pwd)"
+APPLICATION_PROPERTIES=application.properties
+TEST_APPLICATION_PROPERTIES=test.application.properties
+
+rsync $JENKINS_CDD_PROPERTIES_DIRECTORY/$APPLICATION_PROPERTIES $CDD_DIRECTORY/src/main/resources
+rsync $JENKINS_CDD_PROPERTIES_DIRECTORY/$TEST_APPLICATION_PROPERTIES $CDD_DIRECTORY/src/test/resources

--- a/integration-tests/test-cdd-dependent-tools.sh
+++ b/integration-tests/test-cdd-dependent-tools.sh
@@ -19,6 +19,7 @@ EXPECTED_METADATA_HEADERS=$CDD_DIRECTORY/integration-tests/expected_metadata_hea
 JENKINS_USER_HOME_DIRECTORY=/var/lib/jenkins
 JENKINS_PROPERTIES_DIRECTORY=$JENKINS_USER_HOME_DIRECTORY/pipelines-configuration/properties
 APPLICATION_PROPERTIES=application.properties
+TEST_APPLICATION_PROPERTIES=test.application.properties
 
 REDCAP_EXPORT_TEST_SUCCESS=0
 ADD_TEST_CDD_HEADERS_SUCCESS=0
@@ -62,7 +63,8 @@ function find_free_port {
 
 # Copy in CDD properties and build jar
 rsync $JENKINS_PROPERTIES_DIRECTORY/clinical-data-dictionary/$APPLICATION_PROPERTIES $CDD_DIRECTORY/src/main/resources
-cd $CDD_DIRECTORY ; mvn package -Dpackaging.type=jar
+rsync $JENKINS_PROPERTIES_DIRECTORY/clinical-data-dictionary/$TEST_APPLICATION_PROPERTIES $CDD_DIRECTORY/src/test/resources
+cd $CDD_DIRECTORY ; mvn package -DskipTests=true -Dpackaging.type=jar
 
 #start up CDD on some port on dashi-dev
 CDD_PORT=`find_free_port`

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
         <includes>
             <include>**/application.properties</include>
             <include>**/ehcache.xml</include>
+            <include>**/ehcache_backup.xml</include>
             <include>**/log4j.properties</include>
         </includes>
       </resource>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
     <finalName>cdd</finalName>
     <filters>
         <filter>src/main/resources/application.properties</filter>
+        <filter>src/test/resources/application.properties</filter>
     </filters>
     <resources>
       <resource>
@@ -190,7 +191,7 @@
     <!-- enable filtering on test resources -->
     <testResources>
       <testResource>
-        <directory>src/main/resources</directory>
+        <directory>src/test/resources</directory>
         <filtering>true</filtering>
         <includes>
             <include>**/application.properties</include>

--- a/src/main/java/org/cbioportal/cdd/config/CDDAppConfig.java
+++ b/src/main/java/org/cbioportal/cdd/config/CDDAppConfig.java
@@ -18,13 +18,15 @@
 
 package org.cbioportal.cdd.config;
 
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import org.ehcache.jsr107.EhcacheCachingProvider;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.jcache.JCacheCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import javax.cache.CacheManager;
-import javax.cache.spi.CachingProvider;
-import org.ehcache.jsr107.EhcacheCachingProvider;
 
 /**
  *
@@ -34,10 +36,15 @@ import org.ehcache.jsr107.EhcacheCachingProvider;
 @EnableCaching
 public class CDDAppConfig {
 
+    @Bean
+    public CachingProvider cachingProvider() throws Exception {
+        CachingProvider cachingProvider = new EhcacheCachingProvider();
+        return cachingProvider;
+    }
+    
     @Bean(destroyMethod = "close")
     public CacheManager cddCacheManager() throws Exception {
-        CachingProvider cachingProvider = new EhcacheCachingProvider();
-        return cachingProvider.getCacheManager(getClass().getClassLoader().getResource("ehcache.xml").toURI(),
+        return cachingProvider().getCacheManager(getClass().getClassLoader().getResource("ehcache.xml").toURI(),
             getClass().getClassLoader());
     }
 

--- a/src/main/java/org/cbioportal/cdd/service/internal/ClinicalAttributeMetadataPersistentCache.java
+++ b/src/main/java/org/cbioportal/cdd/service/internal/ClinicalAttributeMetadataPersistentCache.java
@@ -56,10 +56,10 @@ public class ClinicalAttributeMetadataPersistentCache {
     public static final String CLINICAL_ATTRIBUTES_METADATA_CACHE_KEY = "CLINICAL_ATTRIBUTES_METADATA_CACHE_KEY";
     public static final String OVERRIDES_CACHE_KEY = "OVERRIDES_CACHE_KEY";
 
-    public CacheManager getBackupCacheManager(String ehcacheXML) throws Exception {
+    public CacheManager getCacheManager(String ehcacheXMLFilename) throws Exception {
         CacheManager cacheManager = cachingProvider.getCacheManager(getClass().getClassLoader().getResource(ehcacheXML).toURI(), getClass().getClassLoader());
         return cacheManager;
-    } 
+    }
 
     // retrieve cached TopBraid responses from default EHCache location
     @Cacheable(value = "clinicalAttributeMetadataEHCache", key = "#root.target.CLINICAL_ATTRIBUTES_METADATA_CACHE_KEY", unless = "#result==null")
@@ -75,20 +75,20 @@ public class ClinicalAttributeMetadataPersistentCache {
     // retrieve cache TopBraid responses from backup EHCache location (and re-populate default EHCache locatin)
     @Cacheable(value = "clinicalAttributeMetadataEHCache", key = "#root.target.CLINICAL_ATTRIBUTES_METADATA_CACHE_KEY", unless = "#result==null")
     public ArrayList<ClinicalAttributeMetadata> getClinicalAttributeMetadataFromPersistentCacheBackup() throws Exception {
-        CacheManager backupCacheManager = getBackupCacheManager("ehcache_backup.xml"); 
+        CacheManager backupCacheManager = getCacheManager("ehcache_backup.xml");
         ArrayList<ClinicalAttributeMetadata> clinicalAttributeMetadata = (ArrayList<ClinicalAttributeMetadata>)backupCacheManager.getCache(CLINICAL_ATTRIBUTE_METADATA_CACHE).get(CLINICAL_ATTRIBUTES_METADATA_CACHE_KEY);
         backupCacheManager.close();
         return clinicalAttributeMetadata;
     }
-   
+
     @Cacheable(value = "clinicalAttributeMetadataOverridesEHCache", key = "#root.target.OVERRIDES_CACHE_KEY", unless = "#result==null")
     public Map<String, ArrayList<ClinicalAttributeMetadata>> getClinicalAttributeMetadataOverridesFromPersistentCacheBackup() throws Exception {
-        CacheManager backupCacheManager = getBackupCacheManager("ehcache_backup.xml");
+        CacheManager backupCacheManager = getCacheManager("ehcache_backup.xml");
         Map<String, ArrayList<ClinicalAttributeMetadata>> clinicalAttributeMetadataOverrides = (Map<String, ArrayList<ClinicalAttributeMetadata>>)backupCacheManager.getCache(OVERRIDES_CACHE).get(OVERRIDES_CACHE_KEY);
         backupCacheManager.close();
         return clinicalAttributeMetadataOverrides;
     }
-    
+
     // update default EHCache location with TopBraid data
     @CachePut(value = "clinicalAttributeMetadataEHCache", key = "#root.target.CLINICAL_ATTRIBUTES_METADATA_CACHE_KEY", unless = "#result==null")
     public ArrayList<ClinicalAttributeMetadata> updateClinicalAttributeMetadataInPersistentCache() {
@@ -104,13 +104,13 @@ public class ClinicalAttributeMetadataPersistentCache {
 
     // update backup EHCache location with modeled-object cache values
     public void backupClinicalAttributeMetadataPersistentCache(ArrayList<ClinicalAttributeMetadata> clinicalAttributeMetadata) throws Exception {
-        CacheManager cacheManager = getBackupCacheManager("ehcache_backup.xml");       
+        CacheManager cacheManager = getCacheManager("ehcache_backup.xml");
         cacheManager.getCache(CLINICAL_ATTRIBUTE_METADATA_CACHE).put(CLINICAL_ATTRIBUTES_METADATA_CACHE_KEY, clinicalAttributeMetadata);
         cacheManager.close();
     }
 
     public void backupClinicalAttributeMetadataOverridesPersistentCache(Map<String, ArrayList<ClinicalAttributeMetadata>> clinicalAttributeMetadataOverrides) throws Exception {
-        CacheManager cacheManager = getBackupCacheManager("ehcache_backup.xml");       
+        CacheManager cacheManager = getCacheManager("ehcache_backup.xml");
         cacheManager.getCache(OVERRIDES_CACHE).put(OVERRIDES_CACHE_KEY, clinicalAttributeMetadataOverrides);
         cacheManager.close();
     }

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -6,6 +6,7 @@ slack.url=
 
 # ehcache properties
 ehcache.persistence.path=
+ehcache.persistence.backup.path=
 ehcache.enable.statistics=false
 ehcache.clinicalAttributeMetadataByStudyCache.maxBytesLocalDiskUnits=
 ehcache.clinicalAttributeMetadataByStudyCache.maxBytesLocalDisk=

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -12,3 +12,4 @@ ehcache.clinicalAttributeMetadataByStudyCache.maxBytesLocalDiskUnits=
 ehcache.clinicalAttributeMetadataByStudyCache.maxBytesLocalDisk=
 ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDiskUnits=
 ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDisk=
+

--- a/src/main/resources/ehcache_backup.xml
+++ b/src/main/resources/ehcache_backup.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ehcache:config
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ehcache="http://www.ehcache.org/v3"
+    xmlns:jcache="http://www.ehcache.org/v3/jsr107"
+    xsi:schemaLocation="
+    http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
+    http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
+    <ehcache:service>
+      <jcache:defaults enable-management="true" enable-statistics="${ehcache.enable.statistics}"/>
+    </ehcache:service>
+    <ehcache:persistence directory="${ehcache.persistence.backup.path}"/>
+
+    <ehcache:cache alias="clinicalAttributeMetadataEHCache">
+      <ehcache:key-type>java.lang.String</ehcache:key-type>
+      <ehcache:value-type>java.util.ArrayList</ehcache:value-type>
+      <ehcache:listeners>
+        <ehcache:listener>
+          <ehcache:class>org.cbioportal.cdd.util.CacheEventLogger</ehcache:class>
+          <ehcache:event-firing-mode>ASYNCHRONOUS</ehcache:event-firing-mode>
+          <ehcache:event-ordering-mode>UNORDERED</ehcache:event-ordering-mode>
+          <ehcache:events-to-fire-on>CREATED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>REMOVED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>UPDATED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>EXPIRED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>EVICTED</ehcache:events-to-fire-on>
+        </ehcache:listener>
+      </ehcache:listeners>
+      <ehcache:resources>
+        <ehcache:heap unit="B">1</ehcache:heap>
+        <ehcache:disk unit="${ehcache.clinicalAttributeMetadataEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.clinicalAttributeMetadataEHCache.maxBytesLocalDisk}</ehcache:disk>
+      </ehcache:resources>
+    </ehcache:cache>
+
+    <ehcache:cache alias="clinicalAttributeMetadataOverridesEHCache">
+      <ehcache:key-type>java.lang.String</ehcache:key-type>
+      <ehcache:value-type>java.util.HashMap</ehcache:value-type>
+      <ehcache:listeners>
+        <ehcache:listener>
+          <ehcache:class>org.cbioportal.cdd.util.CacheEventLogger</ehcache:class>
+          <ehcache:event-firing-mode>ASYNCHRONOUS</ehcache:event-firing-mode>
+          <ehcache:event-ordering-mode>UNORDERED</ehcache:event-ordering-mode>
+          <ehcache:events-to-fire-on>CREATED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>REMOVED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>UPDATED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>EXPIRED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>EVICTED</ehcache:events-to-fire-on>
+        </ehcache:listener>
+      </ehcache:listeners>
+      <ehcache:resources>
+        <ehcache:heap unit="B">1</ehcache:heap>
+        <ehcache:disk unit="${ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDisk}</ehcache:disk>
+      </ehcache:resources>
+    </ehcache:cache>
+
+</ehcache:config>

--- a/src/test/resources/application.properties.EXAMPLE
+++ b/src/test/resources/application.properties.EXAMPLE
@@ -1,0 +1,7 @@
+# ehcache unit test properties
+ehcache.dev.persistence.path=
+ehcache.dev.enable.statistics=false
+ehcache.dev.clinicalAttributeMetadataEHCache.maxBytesLocalDisk=
+ehcache.dev.clinicalAttributeMetadataEHCache.maxBytesLocalDiskUnits=
+ehcache.dev.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDisk=
+ehcache.dev.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDiskUnits=

--- a/src/test/resources/ehcache.xml
+++ b/src/test/resources/ehcache.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ehcache:config
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ehcache="http://www.ehcache.org/v3"
+    xmlns:jcache="http://www.ehcache.org/v3/jsr107"
+    xsi:schemaLocation="
+    http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
+    http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
+    <ehcache:service>
+      <jcache:defaults enable-management="true" enable-statistics="${ehcache.dev.enable.statistics}"/>
+    </ehcache:service>
+    <ehcache:persistence directory="${ehcache.dev.persistence.path}"/>
+
+    <ehcache:cache alias="clinicalAttributeMetadataEHCache">
+      <ehcache:key-type>java.lang.String</ehcache:key-type>
+      <ehcache:value-type>java.util.ArrayList</ehcache:value-type>
+      <ehcache:listeners>
+        <ehcache:listener>
+          <ehcache:class>org.cbioportal.cdd.util.CacheEventLogger</ehcache:class>
+          <ehcache:event-firing-mode>ASYNCHRONOUS</ehcache:event-firing-mode>
+          <ehcache:event-ordering-mode>UNORDERED</ehcache:event-ordering-mode>
+          <ehcache:events-to-fire-on>CREATED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>UPDATED</ehcache:events-to-fire-on>
+        </ehcache:listener>
+      </ehcache:listeners>
+      <ehcache:resources>
+        <ehcache:heap unit="B">1</ehcache:heap>
+        <ehcache:disk unit="${ehcache.dev.clinicalAttributeMetadataEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.dev.clinicalAttributeMetadataEHCache.maxBytesLocalDisk}</ehcache:disk>
+      </ehcache:resources>
+    </ehcache:cache>
+
+    <ehcache:cache alias="clinicalAttributeMetadataOverridesEHCache">
+      <ehcache:key-type>java.lang.String</ehcache:key-type>
+      <ehcache:value-type>java.util.HashMap</ehcache:value-type>
+      <ehcache:listeners>
+        <ehcache:listener>
+          <ehcache:class>org.cbioportal.cdd.util.CacheEventLogger</ehcache:class>
+          <ehcache:event-firing-mode>ASYNCHRONOUS</ehcache:event-firing-mode>
+          <ehcache:event-ordering-mode>UNORDERED</ehcache:event-ordering-mode>
+          <ehcache:events-to-fire-on>CREATED</ehcache:events-to-fire-on>
+          <ehcache:events-to-fire-on>UPDATED</ehcache:events-to-fire-on>
+        </ehcache:listener>
+      </ehcache:listeners>
+      <ehcache:resources>
+        <ehcache:heap unit="B">1</ehcache:heap>
+        <ehcache:disk unit="${ehcache.dev.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDiskUnits}" persistent="true">${ehcache.dev.clinicalAttributeMetadataOverridesEHCache.maxBytesLocalDisk}</ehcache:disk>
+      </ehcache:resources>
+    </ehcache:cache>
+
+</ehcache:config>


### PR DESCRIPTION
- Makes a working backup of the persistent cache when the cache is successfully (re)populated
- If TopBraid is down and main cache is corrupt then reads backup cache
  * Populates in-memory cache from backup
  * Main persistent cache gets repopulated from the backup
- Fixes unit tests
- Has integration test fixes

